### PR TITLE
replace deprecated function

### DIFF
--- a/app/code/core/Mage/Core/Helper/Abstract.php
+++ b/app/code/core/Mage/Core/Helper/Abstract.php
@@ -235,7 +235,11 @@ abstract class Mage_Core_Helper_Abstract
      */
     public function removeTags($html)
     {
-        $html = preg_replace("# <(?![/a-z]) | (?<=\s)>(?![a-z]) #exi", "htmlentities('$0')", $html);
+        $html = preg_replace_callback(
+            "# <(?![/a-z]) | (?<=\s)>(?![a-z]) #xi",
+            function($html){ return htmlentities($html[0]); },
+            $html
+        );
         $html =  strip_tags($html);
         return htmlspecialchars_decode($html);
     }


### PR DESCRIPTION
in PHP 5.5: "The /e modifier is deprecated, use preg_replace_callback"

This patch works only for php 5.3 <= because of the use of an anonymous function.
But would work for 5.2 too, if we created a named function
